### PR TITLE
install python dependencies from requirements.txt

### DIFF
--- a/image_builder/build.py
+++ b/image_builder/build.py
@@ -91,6 +91,7 @@ class ImageBuilder:
     def _update_configuration(self, workflow_folder_path, machine):
         debs = None
         pips = None
+        pip_reqs_path = os.path.join(workflow_folder_path, "requirements.txt")
         environment = {}
         import yaml
         with open(os.path.join(workflow_folder_path, "eflows4hpc.yaml"), 'r') as file:
@@ -99,6 +100,8 @@ class ImageBuilder:
             debs = eflows_environment['apt']
         if 'pip' in eflows_environment:
             pips = eflows_environment['pip']
+        elif os.path.exists(pip_reqs_path): 
+            pips = ["-r", pip_reqs_path]
         if 'spack' in eflows_environment:
             environment['spack'] = eflows_environment['spack']
             if 'architecture' in machine:


### PR DESCRIPTION
The PR adds the possibility of installing Python dependencies directly from a requirements.txt file if present in the workflow directory (the same directory where the eFlows4HPC.yaml lives). 

**Motivation**

- Currently developers need to manually add Python dependencies to the eflows4hpc.yaml file, which is not a convenient or standard practice. Typically the development is done elsewhere and the tree of python dependencies is known a priori. This allows reproducibility of the workflow with the same versioning of the python dependencies. 
- Same versioning of the Python dependencies is ensured regardless if the Spack base version powering the installation and management of the software stack will change in the future. Further, the Spack concretizer is influenced by different configurations parameters that may vary across platforms/HPC clusters such as the MPI version

The same reasoning would be applicable to the spack software stack installation by provisioning a Spack.lock. 

**Solution**
Basically, if a `requirements.txt` file is detected in the same directory as the `eFlows4HPC.yaml` file, then the variable `pips` takes the value `["-r", "path/to/requirements.txt"]`. Perhaps something more explicit is desirable instead?