### PR TITLE
dropdown filtered list of the spack architectures as a user is typing

### DIFF
--- a/blueprints/dashboard.py
+++ b/blueprints/dashboard.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, render_template, request, flash, redirect, url_for, Response
 from flask_login import login_required, current_user
 from builder_service import db, Build, Image, User, build_image, get_build_logs_path, remove_build
+from image_builder.utils import SPACK_ARCHITECTURES
 import time
 
 dashboard = Blueprint('dashboard', __name__)
@@ -55,7 +56,7 @@ def delete_build(id):
 @dashboard.route('/builds/new')
 @login_required
 def new_build():
-    return render_template('request.html')
+    return render_template('request.html', architectures=SPACK_ARCHITECTURES)
 
 
 @dashboard.route('/builds/new', methods=['POST'])

--- a/templates/request.html
+++ b/templates/request.html
@@ -29,9 +29,13 @@
                     </div>
                 </div>
                 <div class="field">
-                    <div class="control">
-                        <input required  class="input is-large" type="" name="architecture" placeholder="Processor Architecture">
-                    </div>
+                    <input list="architecture" name="architecture" placeholder="-- Processor Architecture --" required>
+                    <datalist id="architecture">
+                        <option value="-- Processor Architecture --" label="-- Processor Architecture --"></option>
+                        {% for architecture in architectures %}
+                            <option value="{{ architecture }}" label="{{ architecture }}"></option>
+                        {% endfor %}
+                    </datalist>
                 </div>
                 <div class="field">
                     <div class="select is-large">


### PR DESCRIPTION
**Feature request**
PR should improve ease of use of the UI when requesting the build of a new image. 

**Motivation**
Currently, a user can not know about the supported SPACK_ARCHITECTURES unless it navigates to the repository https://github.com/eflows4hpc/image_creation/blob/new_developments/image_builder/utils.py

**Solution**
The SPACK_ARCHITECTURES list is passed as an argument to the flask `render_template` call. The architectures now appear as a list in the UI and are filtered as the user starts typing. The list is rendered still using pure html syntax